### PR TITLE
Add the class "touched" to element after blur occurs

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -124,12 +124,19 @@
 							_validate:{},
 							valid: true,
 							modified: false,
+							touched: false,
 							invalid: false
 						});
 						
 						this._onValidate = vm.$on('validate', function () {
 							this.validate(model);
 						}.bind(this));
+
+						this._onBlur = function () {
+							this.el.classList.add('touched');
+							vm.$set('validator.'+model+'.touched', true);
+						}.bind(this);
+						_.on(this.el,'blur', this._onBlur);
 
 						Vue.nextTick(function () {
 							startValue = this.vm.$get(model);


### PR DESCRIPTION
This is useful if you want to provide life feedback to the user
(when not using lazy option), but only after the first blur ocurrs,
so it is not anoying the first time the user fills the input.

Closes #4
