### PR TITLE
Support validation on duplicate fields

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -127,7 +127,7 @@
 							touched: false,
 							invalid: false
 						});
-						
+					}
 						this._onValidate = vm.$on('validate', function () {
 							this.validate(model);
 						}.bind(this));
@@ -147,7 +147,7 @@
 							}.bind(this),true);
 
 						}.bind(this));
-					}
+
 
 					vm.$set('validator.'+model+'._validate.'+(this.arg || this.expression), this.expression);
 


### PR DESCRIPTION
If duplicated fields were present on the page, only the first one was getting validated and styled.
This commit enables validation on all duplicated fields.

Closes #6
